### PR TITLE
bugfix/accurics_remediation_40582852601019437 - Auto Generated Pull Request From Accurics

### DIFF
--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -8,6 +8,12 @@ resource "aws_launch_configuration" "aws_autoscale_conf" {
   instance_type = "t2.micro"
   # Defining the Key that will be used to access the AWS EC2 instance
   key_name = "automateinfra"
+
+  ebs_block_device {
+    delete_on_termination = true
+    device_name           = "<ebs_device_name>"
+    encrypted             = true
+  }
 }
 
 # Creating the autoscaling group within us-east-1a availability zone


### PR DESCRIPTION
A cluster in a region where Amazon EC2 encryption of EBS volumes is enabled by default will have EBS volumes encrypted even if local disk encryption is not enabled. The EBS encryption option encrypts the EBS root device volume and attached storage volumes. The EBS encryption option is available only when AWS KMS is used as key provider.